### PR TITLE
Add missing argument to example

### DIFF
--- a/haskell/System/Console/Isocline.hs
+++ b/haskell/System/Console/Isocline.hs
@@ -56,7 +56,7 @@ interaction
 completer :: `CompletionEnv` -> String -> IO () 
 completer cenv input
   = do `completeFileName` cenv input Nothing [\".\",\"\/usr\/local\"] [\".hs\"]  -- use [] for any extension
-       `completeWord` cenv input wcompleter
+       `completeWord` cenv input Nothing wcompleter
 
 wcompleter :: String -> [`Completion`]
 wcompleter input


### PR DESCRIPTION
```haskell
completeWord :: CompletionEnv -> String -> Maybe (Char -> Bool) -> (String -> [Completion]) -> IO ()
```
