### PR TITLE
Fix MSVC warnings on level 4

### DIFF
--- a/src/isocline.c
+++ b/src/isocline.c
@@ -13,7 +13,12 @@
 // $ gcc -c src/isocline.c 
 //-------------------------------------------------------------
 #if !defined(IC_SEPARATE_OBJS)
-# define _CRT_SECURE_NO_WARNINGS  // for msvc
+# ifndef _CRT_NONSTDC_NO_WARNINGS
+#  define _CRT_NONSTDC_NO_WARNINGS // for msvc
+# endif
+# ifndef _CRT_SECURE_NO_WARNINGS
+#  define _CRT_SECURE_NO_WARNINGS  // for msvc
+# endif
 # define _XOPEN_SOURCE   700      // for wcwidth
 # define _DEFAULT_SOURCE          // ensure usleep stays visible with _XOPEN_SOURCE >= 700
 # include "attr.c"


### PR DESCRIPTION
This change fixes the warning in isatty():

term.c(335,31): warning C4996: 'isatty': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _isatty. See online help for details. [D:\a\luau\luau\isocline.vcxproj]

As well as making sure to define these conditionally to avoid this warning when they are set externally as part of the build process:

isocline.c(16,1): warning C4005: '_CRT_SECURE_NO_WARNINGS': macro redefinition [D:\a\luau\luau\isocline.vcxproj]