### PR TITLE
Twoliner prompt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,7 @@ doc/html/
 *.lock
 history.txt
 isocline.debug.txt
+.gdb_history
+history*
+src/cscope.out
+test/example_rc.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,11 @@ target_compile_options(example PRIVATE ${ic_cflags})
 target_include_directories(example PRIVATE include)
 target_link_libraries(example PRIVATE isocline)
 
+add_executable(example_rc test/example_rc.c)
+target_compile_options(example_rc PRIVATE ${ic_cflags})
+target_include_directories(example_rc PRIVATE include)
+target_link_libraries(example_rc PRIVATE isocline)
+
 add_executable(test_colors test/test_colors.c)
 target_compile_options(test_colors PRIVATE ${ic_cflags})
 target_include_directories(test_colors PRIVATE include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,11 +156,6 @@ target_compile_options(example PRIVATE ${ic_cflags})
 target_include_directories(example PRIVATE include)
 target_link_libraries(example PRIVATE isocline)
 
-add_executable(example_rc test/example_rc.c)
-target_compile_options(example_rc PRIVATE ${ic_cflags})
-target_include_directories(example_rc PRIVATE include)
-target_link_libraries(example_rc PRIVATE isocline)
-
 add_executable(test_colors test/test_colors.c)
 target_compile_options(test_colors PRIVATE ${ic_cflags})
 target_include_directories(test_colors PRIVATE include)

--- a/include/isocline.h
+++ b/include/isocline.h
@@ -332,7 +332,7 @@ const char* ic_get_continuation_prompt_marker(void);
 
 /// Disable or enable printing marker on a separate line (disabled by default).
 /// Returns the previous setting.
-bool ic_enable_marker_on_next_line(bool enable);
+bool ic_enable_twoline_prompt(bool enable);
 
 /// Disable or enable multi-line input (enabled by default).
 /// Returns the previous setting.

--- a/include/isocline.h
+++ b/include/isocline.h
@@ -330,6 +330,10 @@ const char* ic_get_prompt_marker(void);
 /// Get the current continuation prompt marker.
 const char* ic_get_continuation_prompt_marker(void);
 
+/// Disable or enable printing marker on a separate line (disabled by default).
+/// Returns the previous setting.
+bool ic_enable_marker_on_next_line(bool enable);
+
 /// Disable or enable multi-line input (enabled by default).
 /// Returns the previous setting.
 bool ic_enable_multiline( bool enable );

--- a/src/editline.c
+++ b/src/editline.c
@@ -163,10 +163,11 @@ static bool edit_pos_is_at_row_end( ic_env_t* env, editor_t* eb ) {
   return rc.last_on_row;
 }
 
-static void edit_write_prompt( ic_env_t* env, editor_t* eb, ssize_t row, bool in_extra ) {
+static void edit_write_prompt( ic_env_t* env, editor_t* eb, ssize_t row, bool in_extra, bool in_line) {
+  debug_msg("edit: write prompt, row: %d, in extra: %s\n", row, in_extra ? "yes" : "no");
   if (in_extra) return;
   bbcode_style_open(env->bbcode, "ic-prompt");
-  if (row==0) {
+  if (row==0 && !in_line) {
     // regular prompt text    
     bbcode_print( env->bbcode, eb->prompt_text );
   }
@@ -212,7 +213,7 @@ static bool edit_refresh_rows_iter(
   if (row > info->last_row)  return true; // should not occur
   
   // term_clear_line(term);
-  edit_write_prompt(info->env, info->eb, row, info->in_extra);
+  edit_write_prompt(info->env, info->eb, row, info->in_extra, true);
 
   //' write output
   if (info->attrs == NULL || (info->env->no_highlight && info->env->no_bracematch)) {
@@ -873,7 +874,7 @@ static char* edit_line( ic_env_t* env, const char* prompt_text )
   }
   
   // show prompt
-  edit_write_prompt(env, &eb, 0, false);   
+  edit_write_prompt(env, &eb, 0, false, false);
 
   // always a history entry for the current input
   history_push(env->history, "");

--- a/src/editline.c
+++ b/src/editline.c
@@ -389,6 +389,7 @@ static void edit_clear(ic_env_t* env, editor_t* eb ) {
 static void edit_clear_screen(ic_env_t* env, editor_t* eb ) {
   ssize_t cur_rows = eb->cur_rows;
   eb->cur_rows = term_get_height(env->term) - 1;
+  if (env->marker_on_next_line) eb->cur_rows--;
   edit_clear(env,eb);
   eb->cur_rows = cur_rows;
   edit_refresh(env,eb);

--- a/src/editline.c
+++ b/src/editline.c
@@ -137,7 +137,7 @@ static void edit_get_prompt_width( ic_env_t* env, editor_t* eb, bool in_extra, s
     ssize_t markerw = bbcode_column_width(env->bbcode, env->prompt_marker);
     ssize_t cmarkerw = bbcode_column_width(env->bbcode, env->cprompt_marker);
     *promptw = markerw;
-    if (!env->marker_on_next_line) *promptw += textw;
+    if (!env->twoline_prompt) *promptw += textw;
     *cpromptw = (env->no_multiline_indent || *promptw < cmarkerw ? cmarkerw : *promptw);
   }
 }
@@ -165,12 +165,12 @@ static bool edit_pos_is_at_row_end( ic_env_t* env, editor_t* eb ) {
 
 static void edit_write_prompt( ic_env_t* env, editor_t* eb, ssize_t row, bool in_extra, bool marker_only) {
   if (in_extra) return;
-  if (!env->marker_on_next_line) marker_only = false;
+  if (!env->twoline_prompt) marker_only = false;
   bbcode_style_open(env->bbcode, "ic-prompt");
   if (!marker_only && row==0) {
     // regular prompt text    
     bbcode_print( env->bbcode, eb->prompt_text );
-    if (env->marker_on_next_line) term_writeln(env->term,"");
+    if (env->twoline_prompt) term_writeln(env->term,"");
   }
   else if (!env->no_multiline_indent) {
     // multiline continuation indentation
@@ -389,7 +389,7 @@ static void edit_clear(ic_env_t* env, editor_t* eb ) {
 static void edit_clear_screen(ic_env_t* env, editor_t* eb ) {
   ssize_t cur_rows = eb->cur_rows;
   eb->cur_rows = term_get_height(env->term) - 1;
-  if (env->marker_on_next_line) eb->cur_rows--;
+  if (env->twoline_prompt) eb->cur_rows--;
   edit_clear(env,eb);
   eb->cur_rows = cur_rows;
   edit_refresh(env,eb);

--- a/src/editline.c
+++ b/src/editline.c
@@ -126,18 +126,37 @@ static bool editor_pos_is_at_end(editor_t* eb ) {
 // Row/Column width and positioning
 //-------------------------------------------------------------
 
+// static void edit_get_prompt_width( ic_env_t* env, editor_t* eb, bool in_extra, ssize_t* promptw, ssize_t* cpromptw, bool in_line ) {
+  // if (in_extra) {
+    // *promptw = 0;
+    // *cpromptw = 0;
+  // }
+  // else {
+    // // todo: cache prompt widths
+    // ssize_t textw = bbcode_column_width(env->bbcode, eb->prompt_text);
+    // ssize_t markerw = bbcode_column_width(env->bbcode, env->prompt_marker);
+    // ssize_t cmarkerw = bbcode_column_width(env->bbcode, env->cprompt_marker);
+    // if (in_line) {
+      // *promptw = markerw;
+    // } else {
+      // *promptw = markerw + textw;
+    // }
+    // *cpromptw = (env->no_multiline_indent || *promptw < cmarkerw ? cmarkerw : *promptw);
+  // }
+// }
 
-static void edit_get_prompt_width( ic_env_t* env, editor_t* eb, bool in_extra, ssize_t* promptw, ssize_t* cpromptw ) {
+static void edit_get_prompt_width( ic_env_t* env, editor_t* eb, bool in_extra, ssize_t* promptw, ssize_t* cpromptw) {
   if (in_extra) {
     *promptw = 0;
     *cpromptw = 0;
   }
   else {
     // todo: cache prompt widths
-    ssize_t textw = bbcode_column_width(env->bbcode, eb->prompt_text);
+    // ssize_t textw = bbcode_column_width(env->bbcode, eb->prompt_text);
+    ic_unused(eb);
     ssize_t markerw = bbcode_column_width(env->bbcode, env->prompt_marker);
     ssize_t cmarkerw = bbcode_column_width(env->bbcode, env->cprompt_marker);
-    *promptw = markerw + textw;
+    *promptw = markerw;
     *cpromptw = (env->no_multiline_indent || *promptw < cmarkerw ? cmarkerw : *promptw);
   }
 }
@@ -177,9 +196,9 @@ static void edit_write_prompt( ic_env_t* env, editor_t* eb, ssize_t row, bool in
     ssize_t textw = bbcode_column_width(env->bbcode, eb->prompt_text );
     ssize_t markerw = bbcode_column_width(env->bbcode, env->prompt_marker);
     ssize_t cmarkerw = bbcode_column_width(env->bbcode, env->cprompt_marker);      
-    if (cmarkerw < markerw + textw) {
-      term_write_repeat(env->term, " ", markerw + textw - cmarkerw );
-    }
+    // if (cmarkerw < markerw + textw) {
+      // term_write_repeat(env->term, " ", markerw + textw - cmarkerw );
+    // }
   }
   // the marker
   bbcode_print(env->bbcode, (row == 0 ? env->prompt_marker : env->cprompt_marker ));   

--- a/src/editline_completion.c
+++ b/src/editline_completion.c
@@ -223,7 +223,7 @@ again:
     rowcol_t rc;
     edit_get_rowcol(env,eb,&rc);
     edit_clear(env,eb);
-    edit_write_prompt(env,eb,0,false);
+    edit_write_prompt(env,eb,0,false, true);
     term_writeln(env->term, "");
     for(ssize_t i = 0; i < count; i++) {
       const char* display = completions_get_display(env->completions, i, NULL);

--- a/src/env.h
+++ b/src/env.h
@@ -38,7 +38,7 @@ struct ic_env_s {
   char            multiline_eol;       // character used for multiline input ("\") (set to 0 to disable)
   bool            initialized;         // are we initialized?
   bool            noedit;              // is rich editing possible (tty != NULL)
-  bool            marker_on_next_line; // print marker on a separate line
+  bool            twoline_prompt;      // print marker on a separate line
   bool            singleline_only;     // allow only single line editing?
   bool            complete_nopreview;  // do not show completion preview for each selection in the completion menu?
   bool            complete_autotab;    // try to keep completing after a completion?

--- a/src/env.h
+++ b/src/env.h
@@ -22,33 +22,34 @@
 //-------------------------------------------------------------
 
 struct ic_env_s {
-  alloc_t*        mem;              // potential custom allocator
-  ic_env_t*       next;             // next environment (used for proper deallocation)
-  term_t*         term;             // terminal
-  tty_t*          tty;              // keyboard (NULL if stdin is a pipe, file, etc)
-  completions_t*  completions;      // current completions
-  history_t*      history;          // edit history
-  bbcode_t*       bbcode;           // print with bbcodes
-  const char*     prompt_marker;    // the prompt marker (defaults to "> ")
-  const char*     cprompt_marker;   // prompt marker for continuation lines (defaults to `prompt_marker`)
-  ic_highlight_fun_t* highlighter;  // highlight callback
-  void*           highlighter_arg;  // user state for the highlighter.
-  const char*     match_braces;     // matching braces, e.g "()[]{}"
-  const char*     auto_braces;      // auto insertion braces, e.g "()[]{}\"\"''"
-  char            multiline_eol;    // character used for multiline input ("\") (set to 0 to disable)
-  bool            initialized;      // are we initialized?
-  bool            noedit;           // is rich editing possible (tty != NULL)
-  bool            singleline_only;  // allow only single line editing?
-  bool            complete_nopreview; // do not show completion preview for each selection in the completion menu?
-  bool            complete_autotab; // try to keep completing after a completion?
+  alloc_t*        mem;                 // potential custom allocator
+  ic_env_t*       next;                // next environment (used for proper deallocation)
+  term_t*         term;                // terminal
+  tty_t*          tty;                 // keyboard (NULL if stdin is a pipe, file, etc)
+  completions_t*  completions;         // current completions
+  history_t*      history;             // edit history
+  bbcode_t*       bbcode;              // print with bbcodes
+  const char*     prompt_marker;       // the prompt marker (defaults to "> ")
+  const char*     cprompt_marker;      // prompt marker for continuation lines (defaults to `prompt_marker`)
+  ic_highlight_fun_t* highlighter;     // highlight callback
+  void*           highlighter_arg;     // user state for the highlighter.
+  const char*     match_braces;        // matching braces, e.g "()[]{}"
+  const char*     auto_braces;         // auto insertion braces, e.g "()[]{}\"\"''"
+  char            multiline_eol;       // character used for multiline input ("\") (set to 0 to disable)
+  bool            initialized;         // are we initialized?
+  bool            noedit;              // is rich editing possible (tty != NULL)
+  bool            marker_on_next_line; // print marker on a separate line
+  bool            singleline_only;     // allow only single line editing?
+  bool            complete_nopreview;  // do not show completion preview for each selection in the completion menu?
+  bool            complete_autotab;    // try to keep completing after a completion?
   bool            no_multiline_indent; // indent continuation lines to line up under the initial prompt 
-  bool            no_help;          // show short help line for history search etc.
-  bool            no_hint;          // allow hinting?
-  bool            no_highlight;     // enable highlighting?
-  bool            no_bracematch;    // enable brace matching?
-  bool            no_autobrace;     // enable automatic brace insertion?
-  bool            no_lscolors;      // use LSCOLORS/LS_COLORS to colorize file name completions?
-  long            hint_delay;       // delay before displaying a hint in milliseconds
+  bool            no_help;             // show short help line for history search etc.
+  bool            no_hint;             // allow hinting?
+  bool            no_highlight;        // enable highlighting?
+  bool            no_bracematch;       // enable brace matching?
+  bool            no_autobrace;        // enable automatic brace insertion?
+  bool            no_lscolors;         // use LSCOLORS/LS_COLORS to colorize file name completions?
+  long            hint_delay;          // delay before displaying a hint in milliseconds
 };
 
 ic_private char*        ic_editline(ic_env_t* env, const char* prompt_text);

--- a/src/isocline.c
+++ b/src/isocline.c
@@ -180,6 +180,13 @@ ic_public void ic_set_prompt_marker( const char* prompt_marker, const char* cpro
   set_prompt_marker(env, prompt_marker, cprompt_marker);
 }
 
+ic_public bool ic_enable_marker_on_next_line( bool enable ) {
+  ic_env_t* env = ic_get_env(); if (env==NULL) return false;
+  bool prev = env->marker_on_next_line;
+  env->marker_on_next_line = enable;
+  return !prev;
+}
+
 ic_public bool ic_enable_multiline( bool enable ) {
   ic_env_t* env = ic_get_env(); if (env==NULL) return false;
   bool prev = env->singleline_only;

--- a/src/isocline.c
+++ b/src/isocline.c
@@ -180,10 +180,10 @@ ic_public void ic_set_prompt_marker( const char* prompt_marker, const char* cpro
   set_prompt_marker(env, prompt_marker, cprompt_marker);
 }
 
-ic_public bool ic_enable_marker_on_next_line( bool enable ) {
+ic_public bool ic_enable_twoline_prompt( bool enable ) {
   ic_env_t* env = ic_get_env(); if (env==NULL) return false;
-  bool prev = env->marker_on_next_line;
-  env->marker_on_next_line = enable;
+  bool prev = env->twoline_prompt;
+  env->twoline_prompt = enable;
   return !prev;
 }
 

--- a/test/example.c
+++ b/test/example.c
@@ -52,7 +52,7 @@ int main()
   // ic_enable_hint(false);
 
   // enable printing prompt and marker on separate lines
-  ic_enable_marker_on_next_line(true);
+  ic_enable_twoline_prompt(true);
 
   // run until empty input
   char* input;

--- a/test/example.c
+++ b/test/example.c
@@ -51,6 +51,9 @@ int main()
   // inline hinting is enabled by default
   // ic_enable_hint(false);
 
+  // enable printing prompt and marker on separate lines
+  ic_enable_marker_on_next_line(true);
+
   // run until empty input
   char* input;
   while((input = ic_readline("isoclinε")) != NULL)    // ctrl-d returns NULL (as well as errors)


### PR DESCRIPTION
Small patch to add an option for printing the prompt text and marker on separate lines. This gives more room for additional status information, e.g. the current working directory / git status etc. when using isocline in a shell without sacrificing the space for the command itself. Also, the separation between two following commands becomes easier to spot.