### PR TITLE
Fix potential memory leak in `sbuf_split_at`

### DIFF
--- a/src/stringbuf.c
+++ b/src/stringbuf.c
@@ -679,8 +679,9 @@ ic_private ssize_t sbuf_insert_at_n(stringbuf_t* sbuf, const char* s, ssize_t n,
 }
 
 ic_private stringbuf_t* sbuf_split_at( stringbuf_t* sb, ssize_t pos ) {
+  if (pos < 0) return NULL;
   stringbuf_t* res = sbuf_new(sb->mem);
-  if (res==NULL || pos < 0) return NULL;
+  if (res==NULL) return NULL;
   if (pos < sb->count) {
     sbuf_append_n(res, sb->buf + pos, sb->count - pos);
     sb->count = pos;


### PR DESCRIPTION
Avoids allocating `res` in the first place when `pos` is negative.

Fixes #19