### PR TITLE
Make Ctrl-C delete all and return an emptry string (instead returning NULL like Ctrl-D).

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -42,7 +42,7 @@ Include the isocline header in your C or C++ source:
 and call `ic_readline` to get user input with rich editing abilities:
 ```C
 char* input;
-while( (input = ic_readline("prompt")) != NULL ) { // ctrl+d/c or errors return NULL
+while( (input = ic_readline("prompt")) != NULL ) { // ctrl+d or errors return NULL
   printf("you typed:\n%s\n", input); // use the input
   free(input);  
 }

--- a/src/editline.c
+++ b/src/editline.c
@@ -938,17 +938,17 @@ static char* edit_line( ic_env_t* env, const char* prompt_text )
       if (eb.pos == 0 && editor_pos_is_at_end(&eb)) break; // ctrl+D on empty quits with NULL
       edit_delete_char(env,&eb);     // otherwise it is like delete
     } 
-    else if (c == KEY_CTRL_C || c == KEY_EVENT_STOP) {
-      break; // ctrl+C or STOP event quits with NULL
+    else if (c == KEY_EVENT_STOP) {
+      break; // STOP event quits with NULL
     }
     else if (c == KEY_ESC) {
       if (eb.pos == 0 && editor_pos_is_at_end(&eb)) break;  // ESC on empty input returns with empty input
       edit_delete_all(env,&eb);      // otherwise delete the current input
       // edit_delete_line(env,&eb);  // otherwise delete the current line
     }
-    else if (c == KEY_BELL /* ^G */) {
+    else if (c == KEY_BELL /* ^G */ || c == KEY_CTRL_C) {
       edit_delete_all(env,&eb);
-      break; // ctrl+G cancels (and returns empty input)
+      break; // ctrl+G or ctrl+c cancels (and returns empty input)
     }
 
     // Editing Operations
@@ -1112,7 +1112,7 @@ static char* edit_line( ic_env_t* env, const char* prompt_text )
   
   // save result
   char* res; 
-  if ((c == KEY_CTRL_D && sbuf_len(eb.input) == 0) || c == KEY_CTRL_C || c == KEY_EVENT_STOP) {
+  if ((c == KEY_CTRL_D && sbuf_len(eb.input) == 0) || c == KEY_EVENT_STOP) {
     res = NULL;
   }
   else if (!tty_is_utf8(env->tty)) {


### PR DESCRIPTION
This issue was mentioned in #16 

With this change, Ctrl-C does not behave like Ctrl-D any more and programs can differentiate between them. Interactive programs usually do not exit with Ctrl-C (see for example https://github.com/GaloisInc/crucible/issues/1286 )
