### PR TITLE
fix: UTF-8 decoding for 0xEE-0xEF range (fullwidth punctuation)

### DIFF
--- a/src/common.c
+++ b/src/common.c
@@ -234,7 +234,9 @@ ic_private unicode_t unicode_from_qutf8(const uint8_t* s, ssize_t len, ssize_t* 
   // 3 bytes: reject overlong and surrogate halves
   else if (len >= 3 && 
            ((c0 == 0xE0 && s[1] >= 0xA0 && s[1] <= 0xBF && utf8_is_cont(s[2])) ||
-            (c0 >= 0xE1 && c0 <= 0xEC && utf8_is_cont(s[1]) && utf8_is_cont(s[2])) 
+            (c0 >= 0xE1 && c0 <= 0xEC && utf8_is_cont(s[1]) && utf8_is_cont(s[2])) ||
+            (c0 == 0xED && s[1] >= 0x80 && s[1] <= 0x9F && utf8_is_cont(s[2])) || // UTF16 surrogate pair range
+            (c0 >= 0xEE && c0 <= 0xEF && utf8_is_cont(s[1]) && utf8_is_cont(s[2]))
           ))
   {
     if (count != NULL) *count = 3;


### PR DESCRIPTION
## Description

The unicode_from_qutf8() function was missing handling for UTF-8 three-byte sequences starting with 0xEE and 0xEF. This caused fullwidth Chinese punctuation (like `，`, `？`, `（`) to be incorrectly decoded as single-byte "raw" characters, resulting in display corruption (�).

This bug corrupts the display of all 225 characters in the "Halfwidth and Fullwidth Forms" Unicode block (U+FF00..U+FFEF). Checkout [Unicode chart](https://www.compart.com/en/unicode/block/U+FF00).
Also affects other valid Unicode characters in the ranges U+E000-U+ECFF and U+EE00-U+EFFF (parts of the Private Use Area and others).


The PR adds the missing conditions for the 0xEE-0xEF range to the 3-byte UTF-8 decoding branch in `unicode_from_qutf8`.
see also https://datatracker.ietf.org/doc/html/rfc3629 for 3-byte octets representation `1110xxxx 10xxxxxx 10xxxxxx`

### Test
```shell
echo '，' | ./build/example
```
`，` is https://www.compart.com/en/unicode/U+FF0C.

### Bonus

Applying this fix will resolve the issue that display corruption in the Koka REPL when inputting or outputting fullwidth characters.