### PR TITLE
fix tab completion state machine bug

### DIFF
--- a/src/completions.c
+++ b/src/completions.c
@@ -175,7 +175,7 @@ static ssize_t completion_apply( completion_t* cm, stringbuf_t* sbuf, ssize_t po
   ssize_t n = cm->delete_before + cm->delete_after;
   if (ic_strlen(cm->replacement) == n && strncmp(sbuf_string_at(sbuf,start), cm->replacement, to_size_t(n)) == 0) {
     // no changes
-    return -1;
+    return start + n;
   }
   else {
     sbuf_delete_from_to( sbuf, start, pos + cm->delete_after );

--- a/src/editline_completion.c
+++ b/src/editline_completion.c
@@ -261,8 +261,9 @@ static void edit_generate_completions(ic_env_t* env, editor_t* eb, bool autotab)
     if (!autotab) { term_beep(env->term); }
   }
   else if (count == 1) {
+    ssize_t old_pos = eb->pos;
     // complete if only one match    
-    if (edit_complete(env,eb,0 /*idx*/) && env->complete_autotab) {
+    if (edit_complete(env,eb,0 /*idx*/) && env->complete_autotab && eb->pos > old_pos) {
       tty_code_pushback(env->tty,KEY_EVENT_AUTOTAB);
     }    
   }


### PR DESCRIPTION
The logic in the optimization strategy block in completion_apply incorrectly returns -1 when the to-be-completed buffer already perfectly matches the replacement string.

Using a numbered string makes it easy to see exactly how many bytes are eaten. We use the isocline-test sample application and its preconfigured completions.

1. Type `987654321 pri` then press Tab. Result: Completes the longest common prefix (`print`) and activates the menu. The prompt is now `987654321 print`.
2. Press Tab again. Result: The menu cycler evaluates the `print` item. Because it matches the buffer, completion_apply returns -1. The menu silently aborts. Visually, nothing happens (not even `print` is highlighted).
3. Press Tab once more. Result: The prompt mangles into `98765432printer`, highlighting `printer` in the menu. Two characters (the space and the 1) were eaten.

The number of characters eaten perfectly correlates to the length difference between the initial input and the LCP: Starting the three-tab procedure with `987654321 prin` eats 1 character (just the space). If the example didn't contain the `prompt` completion (and your cwd doesn't contain any files or directories whose name starts with p), starting with `987654321 p` would result in `987654printer`, having eaten 4 characters.

The fix is changing the optimization block in completion_apply to return what the caller actually expects on success, namely the new cursor position, which is start + n.