### PR TITLE
implement better fix for autocomplete issues

### DIFF
--- a/src/completions.c
+++ b/src/completions.c
@@ -168,14 +168,19 @@ ic_public bool ic_stop_completing( const ic_completion_env_t* cenv) {
 
 
 static ssize_t completion_apply( completion_t* cm, stringbuf_t* sbuf, ssize_t pos ) {
-  if (cm == NULL) return -1;  
+  if (cm == NULL) return IC_COMP_APPLY_FAIL;
   debug_msg( "completion: apply: %s at %zd\n", cm->replacement, pos);
   ssize_t start = pos - cm->delete_before;
   if (start < 0) start = 0;
   ssize_t n = cm->delete_before + cm->delete_after;
   if (ic_strlen(cm->replacement) == n && strncmp(sbuf_string_at(sbuf,start), cm->replacement, to_size_t(n)) == 0) {
-    // no changes
-    return start + n;
+    // if delete_after > 0, we performed a completion while inside of the word,
+    // so return the actual new cursor position, because eb->pos needs updating
+    if (cm->delete_after > 0)
+      return start + n;
+    // otherwise we can just say nothing happened at all
+    else
+      return IC_COMP_APPLY_NOOP;
   }
   else {
     sbuf_delete_from_to( sbuf, start, pos + cm->delete_after );
@@ -211,7 +216,7 @@ ic_private ssize_t completions_apply_longest_prefix(completions_t* cms, stringbu
 
   // set initial prefix to the first entry
   completion_t* cm = completions_get(cms, 0);
-  if (cm == NULL) return -1;
+  if (cm == NULL) return IC_COMP_APPLY_FAIL;
 
   char prefix[IC_MAX_PREFIX+1];
   ssize_t delete_before = cm->delete_before;
@@ -237,7 +242,7 @@ ic_private ssize_t completions_apply_longest_prefix(completions_t* cms, stringbu
 
   // check the length
   ssize_t len = ic_strlen(prefix);
-  if (len <= 0 || len < delete_before) return -1;
+  if (len <= 0 || len < delete_before) return IC_COMP_APPLY_NOOP;
 
   // we found a prefix :-)
   completion_t cprefix;

--- a/src/completions.h
+++ b/src/completions.h
@@ -23,7 +23,7 @@
 //-------------------------------------------------------------
 // completion couldn't complete
 #define IC_COMP_APPLY_FAIL -1
-// completion didn't end up modifying the buffer
+// completion didn't end up modifying the buffer or cursor position
 #define IC_COMP_APPLY_NOOP -2
 
 typedef struct completions_s completions_t;

--- a/src/completions.h
+++ b/src/completions.h
@@ -18,6 +18,14 @@
 #define IC_MAX_COMPLETIONS_TO_SHOW  (1000)
 #define IC_MAX_COMPLETIONS_TO_TRY   (IC_MAX_COMPLETIONS_TO_SHOW/4)
 
+//-------------------------------------------------------------
+// Magic return values for completion application functions
+//-------------------------------------------------------------
+// completion couldn't complete
+#define IC_COMP_APPLY_FAIL -1
+// completion didn't end up modifying the buffer
+#define IC_COMP_APPLY_NOOP -2
+
 typedef struct completions_s completions_t;
 
 ic_private completions_t* completions_new(alloc_t* mem);

--- a/src/editline_completion.c
+++ b/src/editline_completion.c
@@ -9,29 +9,43 @@
 // Completion menu: this file is included in editline.c
 //-------------------------------------------------------------
 
+// return true if the buffer was actually changed, false otherwise;
+// clean up any dirtiness in the undo stack. update eb->pos if appropriate
+static bool edit_completion_commit(editor_t* eb, ssize_t newpos) {
+  if (newpos == IC_COMP_APPLY_FAIL) {
+    editor_undo_restore(eb, false);
+    return false;
+  }
+  if (newpos == IC_COMP_APPLY_NOOP) {
+    editor_undo_forget(eb);
+    return false;
+  }
+
+  eb->pos = newpos;
+  return true;
+}
+
 // return true if anything changed
 static bool edit_complete(ic_env_t* env, editor_t* eb, ssize_t idx) {
   editor_start_modify(eb);
   ssize_t newpos = completions_apply(env->completions, idx, eb->input, eb->pos);
-  if (newpos < 0) {
-    editor_undo_restore(eb,false);
-    return false;
-  }
-  eb->pos = newpos;
-  edit_refresh(env,eb);  
-  return true;
+  bool buffer_changed = edit_completion_commit(eb, newpos);
+
+  // trigger a refresh if the buffer changed
+  if (buffer_changed)
+    edit_refresh(env, eb);
+  // or when choosing between menu items, even if the current item is the same
+  // as the buffer, because we need to highlight that item
+  else if (newpos == IC_COMP_APPLY_NOOP && completions_count(env->completions) > 1)
+    edit_refresh(env, eb);
+
+  return buffer_changed;
 }
 
-static bool edit_complete_longest_prefix(ic_env_t* env, editor_t* eb ) {
+static void edit_complete_longest_prefix(ic_env_t* env, editor_t* eb ) {
   editor_start_modify(eb);
   ssize_t newpos = completions_apply_longest_prefix( env->completions, eb->input, eb->pos );
-  if (newpos < 0) {
-    editor_undo_restore(eb,false);
-    return false;
-  }
-  eb->pos = newpos;
-  edit_refresh(env,eb);
-  return true;
+  edit_completion_commit(eb, newpos);
 }
 
 ic_private void sbuf_append_tagged( stringbuf_t* sb, const char* tag, const char* content ) {
@@ -150,8 +164,8 @@ again:
     }
   }
   if (!env->complete_nopreview && selected >= 0 && selected <= count_displayed) {
-    edit_complete(env,eb,selected);
-    editor_undo_restore(eb,false);
+    if (edit_complete(env,eb,selected))
+      editor_undo_restore(eb,false);
   }
   else {
     edit_refresh(env, eb);
@@ -203,8 +217,7 @@ again:
     // select the current entry
     assert(selected < count);
     c = 0;      
-    edit_complete(env, eb, selected);    
-    if (env->complete_autotab) {
+    if (edit_complete(env, eb, selected) && env->complete_autotab) {
       tty_code_pushback(env->tty,KEY_EVENT_AUTOTAB); // immediately try to complete again        
     }
   }
@@ -261,9 +274,8 @@ static void edit_generate_completions(ic_env_t* env, editor_t* eb, bool autotab)
     if (!autotab) { term_beep(env->term); }
   }
   else if (count == 1) {
-    ssize_t old_pos = eb->pos;
     // complete if only one match    
-    if (edit_complete(env,eb,0 /*idx*/) && env->complete_autotab && eb->pos > old_pos) {
+    if (edit_complete(env,eb,0 /*idx*/) && env->complete_autotab) {
       tty_code_pushback(env->tty,KEY_EVENT_AUTOTAB);
     }    
   }

--- a/src/editline_completion.c
+++ b/src/editline_completion.c
@@ -9,7 +9,7 @@
 // Completion menu: this file is included in editline.c
 //-------------------------------------------------------------
 
-// return true if the buffer was actually changed, false otherwise;
+// return true iff the buffer or cursor position was actually changed;
 // clean up any dirtiness in the undo stack. update eb->pos if appropriate
 static bool edit_completion_commit(editor_t* eb, ssize_t newpos) {
   if (newpos == IC_COMP_APPLY_FAIL) {
@@ -29,17 +29,17 @@ static bool edit_completion_commit(editor_t* eb, ssize_t newpos) {
 static bool edit_complete(ic_env_t* env, editor_t* eb, ssize_t idx) {
   editor_start_modify(eb);
   ssize_t newpos = completions_apply(env->completions, idx, eb->input, eb->pos);
-  bool buffer_changed = edit_completion_commit(eb, newpos);
+  bool buf_or_pos_changed = edit_completion_commit(eb, newpos);
 
-  // trigger a refresh if the buffer changed
-  if (buffer_changed)
+  // trigger a refresh if the buffer or cursor position changed
+  if (buf_or_pos_changed)
     edit_refresh(env, eb);
   // or when choosing between menu items, even if the current item is the same
   // as the buffer, because we need to highlight that item
   else if (newpos == IC_COMP_APPLY_NOOP && completions_count(env->completions) > 1)
     edit_refresh(env, eb);
 
-  return buffer_changed;
+  return buf_or_pos_changed;
 }
 
 static void edit_complete_longest_prefix(ic_env_t* env, editor_t* eb ) {


### PR DESCRIPTION
the meaning of the -1 return value in the entire completion application state machine was overloaded all along, my previous fix just worked around it by having completion_apply return start + n if the buffer was unchanged, but it left undo states in place that were meaningless (and needlessly refreshed the editor).

this new approach fixes the actual bedrock logic inside completion_apply by distinguishing the 'buffer didn't change' return state with the 'we got an actual error' return state throughout the code, with symbolic constants defined in completions.h.

I noted your recent 270753a92607344b8cf908c49a05a8e2ad527036 commit introduces a case where the buffer is unchanged, but the cursor position has changed. to handle that case, when delete_after is greater than 0, we just return start + n after all so its callers know eb->pos needs updating. now that the return logic in completion_apply actually makes sense, there are several places throughout the code where not ignoring the return value of edit_complete actually makes the code quite elegant.