### PR TITLE
add user-defined inline hint callback

### DIFF
--- a/include/isocline.h
+++ b/include/isocline.h
@@ -293,6 +293,14 @@ typedef char* (ic_highlight_format_fun_t)(const char* s, void* arg);
 /// content of `formatted` without bbcode tags should match `input` exactly.
 void ic_highlight_formatted(ic_highlight_env_t* henv, const char* input, const char* formatted);
 
+/// A hint callback that returns a hint to display inline at the cursor, or NULL for no hint.
+/// The returned string is copied and need not be preserved.
+typedef const char* (ic_hint_fun_t)(const char* input, void* arg);
+
+/// Set a hint callback. Overrides the default completion-derived hint when set.
+/// There can only be one hint function, setting it again disables the previous one.
+void ic_set_default_hinter(ic_hint_fun_t* hinter, void* arg);
+
 /// \}
 
 //--------------------------------------------------------------

--- a/src/editline.c
+++ b/src/editline.c
@@ -456,7 +456,19 @@ static void edit_refresh_hint(ic_env_t* env, editor_t* eb) {
     edit_refresh(env, eb);
     if (env->no_hint) return;
   }
-    
+
+  // user-defined hinter takes priority over completion-derived hint
+  if (env->hinter != NULL) {
+    const char* hint = env->hinter(sbuf_string(eb->input), env->hinter_arg);
+    if (hint != NULL && hint[0] != 0) {
+      sbuf_replace(eb->hint, hint);
+    }
+    if (env->hint_delay <= 0) {
+      edit_refresh(env, eb);
+    }
+    return;
+  }
+
   // and see if we can construct a hint (displayed after a delay)
   ssize_t count = completions_generate(env, env->completions, sbuf_string(eb->input), eb->pos, 2);
   if (count == 1) {

--- a/src/editline_completion.c
+++ b/src/editline_completion.c
@@ -31,9 +31,10 @@ static bool edit_complete(ic_env_t* env, editor_t* eb, ssize_t idx) {
   ssize_t newpos = completions_apply(env->completions, idx, eb->input, eb->pos);
   bool buf_or_pos_changed = edit_completion_commit(eb, newpos);
 
-  // trigger a refresh if the buffer or cursor position changed
+  // trigger a refresh if the buffer or cursor position changed; use the hint
+  // variant so the user-defined hinter fires on a tab-accepted completion
   if (buf_or_pos_changed)
-    edit_refresh(env, eb);
+    edit_refresh_hint(env, eb);
   // or when choosing between menu items, even if the current item is the same
   // as the buffer, because we need to highlight that item
   else if (newpos == IC_COMP_APPLY_NOOP && completions_count(env->completions) > 1)

--- a/src/env.h
+++ b/src/env.h
@@ -33,6 +33,8 @@ struct ic_env_s {
   const char*     cprompt_marker;   // prompt marker for continuation lines (defaults to `prompt_marker`)
   ic_highlight_fun_t* highlighter;  // highlight callback
   void*           highlighter_arg;  // user state for the highlighter.
+  ic_hint_fun_t*  hinter;           // hint callback
+  void*           hinter_arg;       // user state for the hinter.
   const char*     match_braces;     // matching braces, e.g "()[]{}"
   const char*     auto_braces;      // auto insertion braces, e.g "()[]{}\"\"''"
   char            multiline_eol;    // character used for multiline input ("\") (set to 0 to disable)

--- a/src/isocline.c
+++ b/src/isocline.c
@@ -330,6 +330,12 @@ ic_public void ic_set_default_highlighter(ic_highlight_fun_t* highlighter, void*
   env->highlighter_arg = arg;
 }
 
+ic_public void ic_set_default_hinter(ic_hint_fun_t* hinter, void* arg) {
+  ic_env_t* env = ic_get_env(); if (env==NULL) return;
+  env->hinter = hinter;
+  env->hinter_arg = arg;
+}
+
 
 ic_public void ic_free( void* p ) {
   ic_env_t* env = ic_get_env(); if (env==NULL) return;


### PR DESCRIPTION
Adds `ic_set_default_hinter` so applications can render arbitrary hint text instead of relying on the single-completion-suffix default.
Falls through to the existing behavior when the callback returns NULL.