### PR TITLE
add ic_enable_space_completes: optionally accept the selected completion with a space

### DIFF
--- a/include/isocline.h
+++ b/include/isocline.h
@@ -356,6 +356,12 @@ bool ic_enable_auto_tab( bool enable );
 /// Returns the previous setting.
 bool ic_enable_completion_preview( bool enable );
 
+/// Enable or disable that a space accepts the selected completion in the
+/// completion menu and is inserted after it, like the zsh menu selection
+/// or the fish pager (disabled by default).
+/// Returns the previous setting.
+bool ic_enable_space_completes( bool enable );
+
 /// Disable or enable automatic identation of continuation lines in multiline
 /// input so it aligns with the initial prompt.
 /// Returns the previous setting.

--- a/readme.md
+++ b/readme.md
@@ -136,6 +136,7 @@ These are also shown when pressing `F1` on a Isocline prompt. We use `^` as a sh
 | Completion menu   |                                                 |
 |-------------------|-------------------------------------------------|
 | `enter`,`left`    | use the currently selected completion |
+| `space`           | use the selected completion and insert a space (when enabled via `ic_enable_space_completes`) |
 | `1` - `9`         | use completion N from the menu |
 | `tab, down    `   | select the next completion |
 | `shift-tab, up`   | select the previous completion |

--- a/src/editline_completion.c
+++ b/src/editline_completion.c
@@ -221,6 +221,14 @@ again:
       tty_code_pushback(env->tty,KEY_EVENT_AUTOTAB); // immediately try to complete again        
     }
   }
+  else if (env->complete_space && selected >= 0 && c == ' ') {
+    // accept the selected entry and insert the typed space after it (like the
+    // zsh menu selection or the fish pager). space is classified as a virt key
+    // (code <= 0x20) so the preview branch below would discard the selection
+    assert(selected < count);
+    edit_complete(env, eb, selected);
+    // c stays ' ' so it is pushed back below and inserted after the completion
+  }
   else if (!env->complete_nopreview && !code_is_virt_key(c)) {
     // if in preview mode, select the current entry and exit the menu
     assert(selected < count);

--- a/src/env.h
+++ b/src/env.h
@@ -41,6 +41,7 @@ struct ic_env_s {
   bool            singleline_only;  // allow only single line editing?
   bool            complete_nopreview; // do not show completion preview for each selection in the completion menu?
   bool            complete_autotab; // try to keep completing after a completion?
+  bool            complete_space;   // does a space accept the selected entry in the completion menu?
   bool            no_multiline_indent; // indent continuation lines to line up under the initial prompt 
   bool            no_help;          // show short help line for history search etc.
   bool            no_hint;          // allow hinting?

--- a/src/isocline.c
+++ b/src/isocline.c
@@ -236,6 +236,13 @@ ic_public bool ic_enable_completion_preview( bool enable ) {
   return !prev;
 }
 
+ic_public bool ic_enable_space_completes( bool enable ) {
+  ic_env_t* env = ic_get_env(); if (env==NULL) return false;
+  bool prev = env->complete_space;
+  env->complete_space = enable;
+  return prev;
+}
+
 ic_public bool ic_enable_multiline_indent(bool enable) {
   ic_env_t* env = ic_get_env(); if (env==NULL) return false;
   bool prev = env->no_multiline_indent;


### PR DESCRIPTION
# add `ic_enable_space_completes`: optionally accept the selected completion with a space

## Problem

In the completion menu, when an entry is selected (and shown as a preview),
typing a printable character accepts the selection and keeps typing — the
`!code_is_virt_key(c)` branch in `edit_completion_menu`. A space, however, is
classified as a virtual key (`code_is_virt_key` is `KEY_NO_MODS(c) <= 0x20`,
and space is 0x20), so it falls through to the default branch instead: the
menu closes, the selection is silently discarded, and a plain space is
inserted.

Since the preview shows the completion as if it were already inserted, having
it vanish on space is surprising — space is the most common "accept this word
and keep typing" key on a command line. zsh's `menuselect` and the fish pager
both accept the selected entry on space.

## Change

A new opt-in toggle, following the existing `ic_enable_*` pattern:

```c
/// Enable or disable that a space accepts the selected completion in the
/// completion menu and is inserted after it, like the zsh menu selection
/// or the fish pager (disabled by default).
/// Returns the previous setting.
bool ic_enable_space_completes( bool enable );
```

Default is **off**, so behavior is unchanged unless the application asks for
it. When enabled, a space with an entry selected accepts the entry and then
inserts the space after it (the space is pushed back like any other passthrough
key). The new branch mirrors the `selected >= 0` guard of the enter/right/end
branch, so it behaves consistently in both preview and no-preview modes.

23 added lines, no lines removed: one flag in `ic_env_t`, one branch in
`edit_completion_menu`, the setter, the doc comment, and a readme row.

## Testing

- `gcc -Wall -Wextra -c src/isocline.c` — no new warnings vs. main (27 before,
  27 after).
- pty-driven check (test program + driver attached in the PR branch comments):
  completer offering `apple` / `banana` / `cherry`, key sequence
  `TAB` `TAB` `SPACE` `X` `ENTER`:
  - toggle off (default): `LINE=[ X]` — selection discarded, identical to main
  - toggle on: `LINE=[apple X]` — selection accepted, space inserted after
