### PR TITLE
Stop looking for inputs when not in a TTY

### DIFF
--- a/src/editline.c
+++ b/src/editline.c
@@ -6,6 +6,7 @@
 -----------------------------------------------------------------------------*/
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "common.h"
 #include "term.h"
@@ -881,6 +882,10 @@ static char* edit_line( ic_env_t* env, const char* prompt_text )
   // process keys
   code_t c;          // current key code
   while(true) {    
+    if (!isatty(0)) {
+      return NULL;
+    }
+
     // read a character
     term_flush(env->term);
     if (env->hint_delay <= 0 || sbuf_len(eb.hint) == 0) {


### PR DESCRIPTION
Fixes a memory leak.

When you open say the demo `example` or any usage of ic_readline in a new terminal window, then close that window without stopping the program, isocline leaks memory.