### PR TITLE
Issue #50: Fix unused parameter warnings on Cygwin

### DIFF
--- a/src/term.c
+++ b/src/term.c
@@ -1029,7 +1029,7 @@ static void term_update_ansi16(term_t* term) {
   }
   #endif
   // this seems to be unreliable on some systems (Ubuntu+Gnome terminal) so only enable when known ok.
-  #if __APPLE__
+  #if defined(__APPLE__) || defined(__CYGWIN__)
   // otherwise use OSC 4 escape sequence query
   if (tty_start_raw(term->tty)) {
     for(int i = 0; i < 16; i++) {

--- a/src/tty.c
+++ b/src/tty.c
@@ -541,6 +541,7 @@ ic_private bool tty_async_stop(const tty_t* tty) {
 }
 #else
 ic_private bool tty_async_stop(const tty_t* tty) {
+  ic_unused(tty);
   return false;
 }
 #endif


### PR DESCRIPTION
Cygwin mintty terminal supports standard xterm OSC 4 sequences - add Cygwin to code enabled for Mac in `term_update_ansi16`

Fixes #50 