### PR TITLE
Illumos support for isocline terminal-size detection

### DIFF
--- a/src/isocline.c
+++ b/src/isocline.c
@@ -19,7 +19,13 @@
 # ifndef _CRT_SECURE_NO_WARNINGS
 #  define _CRT_SECURE_NO_WARNINGS  // for msvc
 # endif
-# define _XOPEN_SOURCE   700      // for wcwidth
+# if !defined(_XOPEN_SOURCE) || (_XOPEN_SOURCE < 700)
+#  undef _XOPEN_SOURCE
+#  define _XOPEN_SOURCE   700      // for wcwidth
+# endif
+# if defined(__sun) && !defined(__EXTENSIONS__)
+#  define __EXTENSIONS__           // for struct winsize with _XOPEN_SOURCE on illumos
+# endif
 # define _DEFAULT_SOURCE          // ensure usleep stays visible with _XOPEN_SOURCE >= 700
 # include "attr.c"
 # include "bbcode.c"

--- a/src/term.c
+++ b/src/term.c
@@ -4,6 +4,10 @@
   under the terms of the MIT License. A copy of the license can be
   found in the "LICENSE" file at the root of this distribution.
 -----------------------------------------------------------------------------*/
+#if defined(__sun) && !defined(__EXTENSIONS__)
+#define __EXTENSIONS__  // for struct winsize with _XOPEN_SOURCE on illumos
+#endif
+
 #include <string.h>
 #include <stdio.h>
 #include <stdarg.h>
@@ -22,6 +26,9 @@
 #else
 #include <unistd.h>
 #include <errno.h>
+#if defined(__sun)
+#include <sys/termios.h>
+#endif
 #include <sys/ioctl.h>
 #if defined(__linux__)
 #include <linux/kd.h>


### PR DESCRIPTION
Implement illumos support for isocline’s terminal-size detection.

1. Clang++ on illumos can predefine `_XOPEN_SOURCE=600`; undefine/redefine to avoid a redefinition warning.
2. On illumos, define `__EXTENSIONS__` before system headers are included so `struct winsize` and `TIOCGWINSZ` are exposed with `_XOPEN_SOURCE`.
Do this in both `src/isocline.c` (amalgamated builds) and `src/term.c` (separate-object builds).
4. On illumos, include `<sys/termios.h>` because `<sys/ioctl.h>` alone does not expose `struct winsize` or `TIOCGWINSZ`.